### PR TITLE
Clothing Shop - Lower Primary Fix

### DIFF
--- a/Altis_Life.Altis/core/shops/fn_clothingMenu.sqf
+++ b/Altis_Life.Altis/core/shops/fn_clothingMenu.sqf
@@ -10,6 +10,8 @@
 private["_list","_clothes","_pic","_filter","_pos","_oldPos","_oldDir","_flag","_shopTitle","_license","_shopSide","_exit"];
 _exit = false;
 
+player setBehaviour "SAFE";
+
 /* License check & config validation */
 if(!isClass(missionConfigFile >> "Clothing" >> (SEL(_this,3)))) exitWith {}; //Bad config entry.
 _shopTitle = M_CONFIG(getText,"Clothing",(SEL(_this,3)),"title");


### PR DESCRIPTION
player PrimaryWeapon holsters while in the shop so its not as broken or goofy. Thanks Heavy Bob :)

Previously you would be in the shop and it would point your primaryweapon and would obstruct the camera. 